### PR TITLE
Change version to 1.0.1 (no code changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,9 @@ mocha
 
 ## Releases
 
+* 2016-07-26 &mdash; __1.0.1__
+  * Fixed a problem with the Babel configuration
+
 * 2016-01-12 &mdash; __1.0.0__
   * Rolled major version to 1 to reflect breaking change in `.list(obj, fragmentId)`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-ptr",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Phillip Clark <phillip@flitbit.com>",
   "description": "A complete implementation of JSON Pointer (RFC 6901) for nodejs and modern browsers.",
   "keywords": [
@@ -49,6 +49,6 @@
   },
   "jspm": {
     "directories": {"lib": "releases"},
-    "main": "json-ptr-1.0.0.min.js"
+    "main": "json-ptr-1.0.1.min.js"
   }
 }

--- a/test/tests.html
+++ b/test/tests.html
@@ -20,7 +20,7 @@
     mocha.setup('bdd')
     </script>
     <!--script src="../index.js"></script-->
-    <script src="../releases/json-ptr-1.0.0.min.js"></script>
+    <script src="../releases/json-ptr-1.0.1.min.js"></script>
     <script src="tests.js"></script>
     <script>
     window.onload = function() {


### PR DESCRIPTION
This fixes #6.

I would like to be able to update to 1.0.0, but I can't because that version contains a Babel misconfiguration. The problem has already been fixed; this PR just bumps the version number. (There are no code changes in this PR.) If you'll be so kind as to release a new version I can start using the latest version of the package again 😄