### PR TITLE
ES2015-specific code was causing errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@
 (function() {
   var root = this; // either the module or the window (in a browser)
   var savedJsonPointer = root.JsonPointer;
+  var $path = Symbol();
+  var $orig = Symbol();
+  var $pointer = Symbol();
+  var $fragmentId = Symbol();
 
   function replace(str, find, repl) {
     // modified from http://jsperf.com/javascript-replace-all/10
@@ -287,11 +291,6 @@
   function pickDecoder(ptr) {
     return (looksLikeFragment(ptr)) ? decodeUriFragmentIdentifier : decodePointer;
   }
-
-  var $path = Symbol();
-  var $orig = Symbol();
-  var $pointer = Symbol();
-  var $fragmentId = Symbol();
 
   class JsonPointer {
 

--- a/index.js
+++ b/index.js
@@ -205,13 +205,13 @@
   }
 
   function compilePointerDereference(path) {
-    let body = `if (typeof(obj) !== 'undefined'`;
+    var body = `if (typeof(obj) !== 'undefined'`;
     if (path.length === 0) {
       return function(root) {
         return root;
       };
     }
-    body = path.reduce((body, p, i) => {
+    body = path.reduce(function(body, p, i) {
       return `${body} &&
     typeof((obj = obj['${replace(path[i], '\\', '\\\\')}'])) !== 'undefined'`;
     }, `if (typeof(obj) !== 'undefined'`);
@@ -288,10 +288,10 @@
     return (looksLikeFragment(ptr)) ? decodeUriFragmentIdentifier : decodePointer;
   }
 
-  let $path = Symbol();
-  let $orig = Symbol();
-  let $pointer = Symbol();
-  let $fragmentId = Symbol();
+  var $path = Symbol();
+  var $orig = Symbol();
+  var $pointer = Symbol();
+  var $fragmentId = Symbol();
 
   class JsonPointer {
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-ptr",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Phillip Clark <phillip@flitbit.com>",
   "description": "A complete implementation of JSON Pointer (RFC 6901) for nodejs and modern browsers.",
   "keywords": [


### PR DESCRIPTION
This merge would remove ES2015-specific code, which was causing iOS Safari to error on the use of the "use strict" command with `let` keywords and the `()=>` form of a function definition.
