### PR TITLE
Creation of arrays with set (force: true)

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,10 +122,13 @@
   function toArrayIndexReference(arr, idx) {
     var len = idx.length;
     var cursor = 0;
-    if (len === 0 || len > 1 && idx[0] === '0') {
+    if (len === 0 || len > 1 && idx[0] === '0' || !isFinite(idx)) {
       return -1;
     }
     if (len === 1 && idx[0] === '-') {
+      if (!Array.isArray(arr)) {
+        return 0;
+      }
       return arr.length;
     }
 
@@ -262,6 +265,11 @@
               if (cursor === end) {
                 it[step] = val;
                 return nonexistent;
+              }
+              // if the next step is an array index, this step should be an array.
+              if (toArrayIndexReference(it[step], path[cursor + 1]) !== -1) {
+                it = it[step] = [];
+                continue;
               }
               it = it[step] = {};
               continue;

--- a/index.js
+++ b/index.js
@@ -122,14 +122,14 @@
   function toArrayIndexReference(arr, idx) {
     var len = idx.length;
     var cursor = 0;
-    if (len === 0 || len > 1 && idx[0] === '0' || !isFinite(idx)) {
-      return -1;
-    }
     if (len === 1 && idx[0] === '-') {
       if (!Array.isArray(arr)) {
         return 0;
       }
       return arr.length;
+    }
+    if (len === 0 || len > 1 && idx[0] === '0' || !isFinite(idx)) {
+      return -1;
     }
 
     while (++cursor < len) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -200,6 +200,37 @@
           });
         });
 
+        describe('a URI fragment identifier of `#/newArray/0`', function() {
+          var p = ptr.create('#/newArray/0');
+
+          it('#get should resolve to undefined', function() {
+            expect(p.get(data)).to.equal(undefined);
+          });
+
+          it('#set with force should succeed creating an array and setting the referenced value', function() {
+            var capture = p.get(data);
+            var updated = {
+              this: 'should succeed'
+            };
+            p.set(data, updated, true);
+            expect(data.newArray).to.be.an('array');
+            expect(p.get(data)).to.eql(updated);
+            p.set(data, capture);
+          });
+
+          it('should have a path of [ "newArray", "0" ]', function() {
+            expect(p.path).to.eql(['newArray', '0']);
+          });
+
+          it('should have the pointer `/newArray/0`', function() {
+            expect(p.pointer).to.eql('/newArray/0');
+          });
+
+          it('should have the URI fragment identfier `#/newArray/0`', function() {
+            expect(p.uriFragmentIdentifier).to.eql('#/newArray/0');
+          });
+        });
+
         describe('with a JSON pointer of `/`', function() {
           var p = ptr.create('/');
 


### PR DESCRIPTION
This allows the creation of arrays with set (force: true).

This should probably be a semver major bump, in case anyone is relying on the past behaviour:

`ptr.set(data, '#/names/0', 'Dan', true);`

Used to result in: `{ names: { 0: 'Dan' } }`

It now results in: `{ names: ['Dan'] }`