### PR TITLE
Prototype pollution (Fixed)

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -172,6 +172,9 @@ export function setValueAtPath(target: unknown, val: unknown, path: PathSegments
   let p: number;
   while (++cursor < len) {
     step = path[cursor];
+    if (step === '__proto__' || step === 'constructor' || step === 'prototype') {
+      throw new Error('Prototype pollution attempt detected.');
+    }
     if (Array.isArray(it)) {
       if (step === '-' && cursor === end) {
         it.push(val);


### PR DESCRIPTION
Hi,
This package is vulnerable to prototype pollution. 
POC
```javascript
var {JsonPointer } = require("json-ptr")
var obj = {}
console.log("Before : " + obj.polluted);
JsonPointer.set(obj,'/__proto__/polluted','Yes! Its Polluted', true);
var obj1 ={}
console.log("After : " + obj1.polluted);
```
Fixed prototype pollution in `util.ts`. 
Thanks