### PR TITLE
fixes #28 and #30

### DIFF
--- a/__tests__/ptr.spec.ts
+++ b/__tests__/ptr.spec.ts
@@ -975,6 +975,7 @@ describe('JsonPointer', function () {
     });
   });
 });
+
 describe('when data contains an array early in the path', function () {
   const data = {
     foo: [] as number[],
@@ -1021,4 +1022,22 @@ describe('concat pointers', function () {
       expect(ptr1.concat(ptr2.uriFragmentIdentifier).toString()).to.eql(result);
     },
   );
+});
+
+interface Hacked {
+  hacked: boolean;
+}
+
+describe('path segments containing single quote', function () {
+  it('issue 28 proof of fix', function () {
+    expect(JsonPointer.get({}, "/it's bad")).to.eql(undefined);
+  });
+  it('issue 30 proof of fix', function () {
+    JsonPointer.get(
+      {},
+      "/aaa'])) !== 'undefined') {return it;}; Number.hacked = true; if(((['a",
+    );
+    const result = Number as unknown as Hacked;
+    expect(result.hacked).to.eql(undefined);
+  });
 });

--- a/examples/issues/issue-28-PoF.js
+++ b/examples/issues/issue-28-PoF.js
@@ -1,0 +1,14 @@
+const { JsonPointer } = require('../../dist');
+const util = require('util');
+
+var p = new JsonPointer("/I'm/bad");
+console.log(util.inspect(p, false, 9));
+
+var a = p.get({}); // expecting this to return undefined
+console.log(util.inspect(a, false, 9));
+
+p = new JsonPointer(["I'm", "also", "bad"]);
+console.log(util.inspect(p, false, 9));
+
+var a = p.get({}); // expecting this to return undefined
+console.log(util.inspect(a, false, 9));

--- a/examples/issues/issue-30-PoF.js
+++ b/examples/issues/issue-30-PoF.js
@@ -1,0 +1,3 @@
+const { JsonPointer } = require('../../dist');
+JsonPointer.get({},
+  '/aaa\'\]\)\) !== \'undefined\') \{return it;\}; console.log(\'HACKED\'); if((([\'a'); // HACKED

--- a/src/util.ts
+++ b/src/util.ts
@@ -179,7 +179,7 @@ export function compilePointerDereference(path: PathSegments): Dereference {
     return (
       body +
       " && \n\ttypeof((it = it['" +
-      replace(path[i] + '', '\\', '\\\\') +
+      replace(replace(path[i] + '', '\\', '\\\\'), "'", "\\'") +
       "'])) !== 'undefined'"
     );
   }, "if (typeof(it) !== 'undefined'") as string;


### PR DESCRIPTION
Patched bug where a single quote in a path segment was breaking path evaluation. This bug also allowed an injection attack reported [here](https://www.huntr.dev/bounties/2-npm-json-ptr/).

This patch relates to the referenced issues on this repository as well as contributions from the reporter and fixer on the above referenced Huntr issue.