### PR TITLE
Update package.json export statements for TS 4.7 Node ESM Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3839,9 +3839,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mkdirp": {
@@ -8845,9 +8845,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mkdirp": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "pointers",
     "fragmentid"
   ],
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "umd": "./dist/json-ptr.min.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "umd": "dist/json-ptr.min.js",
   "exports": {
     ".": {
       "import": {
@@ -24,7 +24,7 @@
       }
     }
   },
-  "types": "./dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -14,14 +14,9 @@
   "umd": "dist/json-ptr.min.js",
   "exports": {
     ".": {
-      "import": {
-        "default": "./dist/esm/index.js",
-        "types": "./dist/types/index.d.ts"
-      },
-      "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/types/index.d.ts"
-      }
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
     }
   },
   "types": "dist/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,16 +9,22 @@
     "pointers",
     "fragmentid"
   ],
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "umd": "dist/json-ptr.min.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "umd": "./dist/json-ptr.min.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": {
+        "default": "./dist/esm/index.js",
+        "types": "./dist/types/index.d.ts"
+      },
+      "require": {
+        "default": "./dist/cjs/index.js",
+        "types": "./dist/types/index.d.ts"
+      }
     }
   },
-  "types": "dist/types/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Update package.json export statements for TS 4.7 Node ESM Support. See for more information
https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-rc/#ecmascript-module-support-in-node-js

When  v3.1.0 is consumed in a project configured as such, TS presents this error:
```
Could not find a declaration file for module 'json-ptr'. './node_modules/json-ptr/dist/esm/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/json-ptr` if it exists or add a new declaration (.d.ts) file containing `declare module 'json-ptr';`ts(7016)
```

This update uses the simplest format that works in testing, but there is a more verbose option, but not sure of it's impact on other environments:
```json
  "exports": {
    ".": {
      "import": {
        "default": "./dist/esm/index.js",
        "types": "./dist/types/index.d.ts"
      },
      "require": {
        "default": "./dist/cjs/index.js",
        "types": "./dist/types/index.d.ts"
      }
    }
  }
```

I've tried other potential options such as `/// <reference path="" />` directives and trying to include the .d.ts in the tsconfig includes/paths.  These didn't change behaviors, so my guess is the TS team didn't opt for mixed support levels, hence the issue to begin with.

Note,  package-lock also contains the minimist 1.2.5 => 1.2.6 update to address a critical vulnerability in that library.  This matches the changes in the bot PR https://github.com/flitbit/json-ptr/pull/53 